### PR TITLE
Исправить отображение изменений статусов

### DIFF
--- a/tbot/bot.py
+++ b/tbot/bot.py
@@ -2169,14 +2169,11 @@ def create_dispatcher() -> Dispatcher:
             await callback.answer("Нет прав для изменения задачи", show_alert=True)
             return
 
-        role = detect_user_role(task, user_id)
-        if role in {"author", "responsible"}:
-            set_all_participants_status(task, TaskStatus.PAUSED)
+        # Даже автор и ответственный ставят на паузу только себя, поэтому не
+        # вызываем массовое обновление статусов участников.
+        set_participant_status(task, user_id, TaskStatus.PAUSED)
+        if task.current_executor_id == user_id:
             task.current_executor_id = None
-        else:
-            set_participant_status(task, user_id, TaskStatus.PAUSED)
-            if task.current_executor_id == user_id:
-                task.current_executor_id = None
 
         task.status_before_overdue = None
         recalc_task_status(task)

--- a/tbot/task_logic.py
+++ b/tbot/task_logic.py
@@ -169,8 +169,17 @@ def filter_activity_feed(
         if entry.actor_id == viewer_id:
             visible.append(entry)
             continue
-        if entry.is_status_change and viewer_id in entry.related_participants:
-            visible.append(entry)
+
+        if not entry.is_status_change:
+            continue
+
+        if viewer_id not in entry.related_participants:
+            continue
+
+        if entry.actor_id == author_id and len(entry.related_participants) > 1:
+            continue
+
+        visible.append(entry)
 
     return visible
 

--- a/tests/test_task_logic.py
+++ b/tests/test_task_logic.py
@@ -181,3 +181,27 @@ def test_filter_activity_feed_for_participant():
     ]
     visible = filter_activity_feed(entries, viewer_id=3, author_id=1)
     assert visible == [entries[1], entries[3]]
+
+
+def test_filter_activity_feed_ignores_mass_author_actions():
+    entries = [
+        ActivityEntry(
+            actor_id=1,
+            description="pause all",
+            is_status_change=True,
+            related_participants=frozenset({2, 3}),
+        ),
+    ]
+    assert filter_activity_feed(entries, viewer_id=2, author_id=1) == []
+
+
+def test_filter_activity_feed_keeps_targeted_author_action():
+    entries = [
+        ActivityEntry(
+            actor_id=1,
+            description="pause one",
+            is_status_change=True,
+            related_participants=frozenset({2}),
+        ),
+    ]
+    assert filter_activity_feed(entries, viewer_id=2, author_id=1) == entries


### PR DESCRIPTION
## Изменения
- Скорректирована фильтрация записей ленты активности, чтобы массовые действия автора не показывались всем участникам.
- Обработчик постановки задачи на паузу больше не меняет статусы всех участников разом.
- Добавлены тесты, покрывающие новую логику фильтрации.

## Тесты
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d392832770832db32404a76a8f84f6