### PR TITLE
Отключить самоуведомления участников задач

### DIFF
--- a/tbot/bot.py
+++ b/tbot/bot.py
@@ -540,6 +540,7 @@ async def notify_task_participants(
     )
 
     recipients = set(get_task_participants(task))
+    recipients.discard(actor_id)
 
     workgroup_participants = set(task.workgroup)
     actor_in_workgroup = actor_id in workgroup_participants

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -45,4 +45,5 @@ def test_workgroup_members_do_not_notify_each_other() -> None:
 
     assert 7247710860 in recipients
     assert 609995295 in recipients
+    assert 1311714242 not in recipients
     assert 678543417 not in recipients


### PR DESCRIPTION
## Описание
- исключил исполнителя действия из списка получателей уведомлений
- дополнил тест уведомлений проверкой отсутствия сообщения для инициатора

## Тестирование
- pytest

